### PR TITLE
make sure unsupported formats aren't identified as play properties

### DIFF
--- a/lib/phrase/formats.rb
+++ b/lib/phrase/formats.rb
@@ -36,7 +36,7 @@ module Phrase
 
     class Base
       def self.supports_extension?(extension)
-        self.extensions.map(&:to_s).include?(extension.to_s) or self.renders_locale_as_extension?
+        self.extensions.map(&:to_s).include?(extension.to_s)
       end
 
       def self.renders_locale_as_extension?
@@ -162,7 +162,7 @@ module Phrase
 
     def self.guess_possible_file_format_from_file_path(file_path)
       extension = extension_from_file_path(file_path)
-      possible_format = SUPPORTED_FORMATS.keys.find do |format|
+      SUPPORTED_FORMATS.keys.find do |format|
         SUPPORTED_FORMATS[format].send(:supports_extension?, extension)
       end
     end

--- a/spec/phrase/formats/play_properties_spec.rb
+++ b/spec/phrase/formats/play_properties_spec.rb
@@ -14,12 +14,6 @@ describe Phrase::Formats::PlayProperties do
     end
   end
 
-  describe "#self.supports_extension?" do
-    subject { Phrase::Formats::PlayProperties.supports_extension?(the_extension) }
-
-    it { should be_true }
-  end
-
   describe "#self.filename_for_locale" do
     subject { Phrase::Formats::PlayProperties.filename_for_locale(the_locale) }
 

--- a/spec/phrase/formats_spec.rb
+++ b/spec/phrase/formats_spec.rb
@@ -443,6 +443,11 @@ describe Phrase::Formats do
       let(:file_path) { "test.xliff" }
       it { should eql :xlf }
     end
+
+    context "file format is unsupported" do
+      let(:file_path) { "test.xxx" }
+      it { should be_nil }
+    end
   end
 end
 


### PR DESCRIPTION
This doesn't cause a bug but I thought it was worth pointing out, in case it was an oversight. Currently when we do
```
Phrase::Formats.send(:guess_possible_file_format_from_file_path, 'anytext') # returns :play_properties
```
In short, for any unrecognised file format, the method always assumes it's a Play Framework Properties file. It doesn't cause any problems currently because play_properties is last in the `SUPPORTED_FORMATS` hash in formats.rb, and since hashes in Ruby 1.9+ are ordered, the other formats are checked first and `:play_properties` will only be picked after all the formats have been exhausted.

This PR adds a test for unrecognised formats and makes sure it returns nil for those cases.