### PR TITLE
if locale is specified, do not allow upload of multiple files

### DIFF
--- a/lib/phrase/tool/commands/push.rb
+++ b/lib/phrase/tool/commands/push.rb
@@ -29,6 +29,9 @@ class Phrase::Tool::Commands::Push < Phrase::Tool::Commands::Base
     if files.empty?
       print_message Rainbow("Could not find any files to upload").bright.red
       exit_command
+    elsif files.size > 1 && @locale.present?
+      print_error "Only a single file can be pushed if locale is specified"
+      exit_command
     else
        interruptable_upload_files(files)
     end
@@ -114,7 +117,7 @@ private
   def file_seems_to_be_utf16?(file)
     Phrase::Tool::EncodingDetector.file_seems_to_be_utf16?(file)
   end
-  
+
   def renders_locale_as_extension?(format_name)
     Phrase::Formats.format_renders_locale_as_extension?(format_name)
   end

--- a/spec/phrase/tool/commands/push_spec.rb
+++ b/spec/phrase/tool/commands/push_spec.rb
@@ -216,8 +216,22 @@ describe Phrase::Tool::Commands::Push do
       it { should == [File.expand_path('spec/fixtures/mixed/nice.yml'), File.expand_path('spec/fixtures/mixed/subfolder/subitem.yml'), File.expand_path('spec/fixtures/mixed/wrong.yml.rb')].sort }
     end
   end
+
+  describe "#execute!" do
+    context "when the locale is passed and multiple files are to be uploaded" do
+      let(:args) { ["--locale=en"]}
+
+      it "should display an error" do
+        subject.should_receive(:print_error).with(/Only a single file can be pushed if locale is specified/i)
+        subject.stub(:choose_files_to_upload).and_return(["a.yml", "b.yml"])
+
+        lambda {
+          subject.execute!
+        }.should raise_error {|error|
+          error.should be_a(SystemExit)
+          error.status.should eq(1)
+        }
+      end
+    end
+  end
 end
-
-
-
-


### PR DESCRIPTION
As a check, `phrase push config/locales --locale=en` would return an error, to prevent uploading of multiple files with the same locale.